### PR TITLE
Add an openrewrite DataTable to create CSV Match reporting

### DIFF
--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/java/search/FindRecipe.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/java/search/FindRecipe.java
@@ -1,0 +1,28 @@
+package dev.snowdrop.openrewrite.java.search;
+
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.AnnotationMatcher;
+
+public abstract class FindRecipe extends Recipe {
+
+    /**
+     * A symbol pattern, expressed as a method pattern to search about: annotation, field, method, etc.
+     * See {@link AnnotationMatcher} for syntax.
+     */
+    @Option(displayName = "Symbol pattern",
+        description = "A symbol pattern, expressed as a method pattern to search about: annotation, field, method, etc.",
+        example = "@java.lang.SuppressWarnings(\"deprecation\")")
+    public String pattern;
+
+    /**
+     * ID of the matching tool needed to reconcile the records where a match took place
+     */
+    @Option(displayName = "Match id",
+        description = "ID of the matching tool needed to reconcile the records where a match took place",
+        required = true)
+    public String matchId;
+
+    @Deprecated
+    public String dummy;
+}

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/java/search/MatchingReport.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/java/search/MatchingReport.java
@@ -14,9 +14,21 @@ public class MatchingReport extends DataTable<MatchingReport.Row> {
 
     @Value
     public static class Row {
+        @Column(displayName = "Match ID",
+            description = "ID of the matching tool used to reconcile the information.")
+        String matchId;
+
         @Column(displayName = "File's type",
             description = "Type of the file where we look for.")
         Type type;
+
+        @Column(displayName = "Symbol searched",
+            description = "Symbol about what we search about: annotation, import, method, filed, etc.")
+        Symbol symbol;
+
+        @Column(displayName = "A symbol pattern",
+            description = "A symbol pattern, expressed as a \"method\" pattern.")
+        String pattern;
 
         @Column(displayName = "Source file path",
             description = "Path of the source file where a match found")
@@ -25,14 +37,6 @@ public class MatchingReport extends DataTable<MatchingReport.Row> {
         @Column(displayName = "FQName of the Class",
             description = "FQName of the Class containing the symbol we search.")
         String className;
-
-        @Column(displayName = "Symbol searched",
-            description = "Symbol about what we search about: annotation, import, method, filed, etc.")
-        String symbol;
-
-        @Column(displayName = "Match ID",
-            description = "ID of the matching tool used to reconcile the information.")
-        String matchId;
     }
 
     public enum Type {
@@ -42,5 +46,12 @@ public class MatchingReport extends DataTable<MatchingReport.Row> {
         JSON,
         YAML,
         PROPERTIES
+    }
+
+    public enum Symbol {
+        ANNOTATION,
+        METHOD,
+        FIELD,
+        CLASS
     }
 }

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/java/search/FindAnnotationTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/java/search/FindAnnotationTest.java
@@ -1,0 +1,41 @@
+package dev.snowdrop.openrewrite.java.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import static org.openrewrite.java.Assertions.java;
+
+public class FindAnnotationTest implements RewriteTest {
+    @Test
+    public void testFindAnnotation() {
+
+        FindAnnotations findAnnotation = new FindAnnotations(false);
+        findAnnotation.matchId = "match-deprecated-001";
+        findAnnotation.pattern = "@java.lang.Deprecated";
+
+        rewriteRun(
+            spec -> spec.dataTableAsCsv(MatchingReport.class,
+                        """
+                        matchId,type,symbol,pattern,sourceFilePath,className
+                        match-deprecated-001,JAVA,ANNOTATION,@java.lang.Deprecated,HomeCinema.java,HomeCinema
+                        """
+                    ).recipe(findAnnotation),
+        java(
+            """
+            public class HomeCinema {
+                @Deprecated
+                public void Display() {
+                    System.out.println("Deprecated display()");
+                }
+            }
+            """,
+            """
+            public class HomeCinema {
+                /*~~>*/@Deprecated
+                public void Display() {
+                    System.out.println("Deprecated display()");
+                }
+            }
+            """
+        ));
+    }
+}


### PR DESCRIPTION
- Add an openrewrite DataTable to create CSV Match reporting
- Review the code of the FindAnnotation recipe to enhance it with new field: matchId and rename annotationPattern to pattern