### PR TITLE
refactor: standardize configuration precedence in analyze command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,21 +126,12 @@ The poc has been designed using the following technology:
 - Java 21 installed and Maven 3.9
 
 ## Setup
-Get the project with git clone and compile it.
 
-First, compile the openrewrite module:
+First git clone this project and compile it.
 
 ```shell
-cd openrewrite-recipes
 mvn clean install -DskipTests
 
-```
-
-Then, the migration-tool project
-
-```shell
-cd ..
-mvn clean install
 ```
 
 ## Konveyor jdt-ls

--- a/migration-tool/src/main/java/dev/snowdrop/analyze/JdtLsFactory.java
+++ b/migration-tool/src/main/java/dev/snowdrop/analyze/JdtLsFactory.java
@@ -62,51 +62,34 @@ public class JdtLsFactory {
     }
 
     public void initProperties(AnalyzeCommand analyzeCommand) {
-        String appPathString = Optional
-            .ofNullable(System.getProperty("APP_PATH"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.appPath))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.app-path", String.class)))
-            .orElseThrow(() -> new RuntimeException("Path to the project to scan is missing !"));
+        String appPathString = analyzeCommand.appPath;
         appPath = resolvePath(appPathString).toString();
 
-        String jdtLsPathString = Optional
-            .ofNullable(System.getProperty("JDT_LS_PATH"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.jdtLsPath))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.jdt-ls-path", String.class)))
-            .orElseThrow(() -> new RuntimeException("JDT_LS_PATH system property is missing !"));
+        String jdtLsPathString = Optional.ofNullable(analyzeCommand.jdtLsPath)
+                .or(()->Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.jdt-ls-path", String.class)))
+                .orElseThrow(() -> new RuntimeException("JDT LS path is required but not configured"));
         jdtLsPath = resolvePath(jdtLsPathString).toString();
 
-        String jdtWksString = Optional
-            .ofNullable(System.getProperty("JDT_WKS"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.jdtWorkspace))
+        String jdtWksString = Optional.ofNullable(analyzeCommand).map(cmd -> cmd.jdtWorkspace)
             .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.jdt-workspace-path", String.class)))
-            .orElseThrow(() -> new RuntimeException("JDT_WKS system property is missing !"));
+            .orElseThrow(() -> new RuntimeException("Jdt workspace is required but not configured"));
         jdtWks = resolvePath(jdtWksString).toString();
 
-        String rulesPathString = Optional
-            .ofNullable(System.getProperty("RULES_PATH"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.rulesPath))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.rules-path", String.class)))
-            .orElseThrow(() -> new RuntimeException("Path of the rules folder is missing !"));
+        lsCmd = Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.jdt-ls-command", String.class))
+                .orElseThrow(() -> new RuntimeException("Command to be executed against the LS server is required but not configured"));
+
+        String rulesPathString = Optional.ofNullable(analyzeCommand.rulesPath)
+                .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.rules-path", String.class)))
+                .orElseThrow(() -> new RuntimeException("Rules path is required but not configured"));
         rulesPath = resolvePath(rulesPathString);
 
-        lsCmd = Optional
-            .ofNullable(System.getProperty("LS_CMD"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.lsCommand))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.jdt-ls-command", String.class)))
-            .orElseThrow(() -> new RuntimeException("Command to be executed against the LS server is missing !"));
+        sourceTechnology = Optional.ofNullable(analyzeCommand.source)
+            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.technology-source", String.class)))
+            .orElseThrow(() -> new RuntimeException("Source technology to analyse required but not configured"));
 
-        sourceTechnology = Optional
-            .ofNullable(System.getProperty("SOURCE_TECHNOLOGY"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.source))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.technology.source", String.class)))
-            .orElseThrow(() -> new RuntimeException("Source technology to analyse is missing !"));
-
-        targetTechnology = Optional
-            .ofNullable(System.getProperty("TARGET_TECHNOLOGY"))
-            .or(() -> Optional.ofNullable(analyzeCommand).map(cmd -> cmd.target))
-            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.technology.target", String.class)))
-            .orElseThrow(() -> new RuntimeException("Target technology to analyse is missing !"));
+        targetTechnology = Optional.ofNullable(analyzeCommand.target)
+            .or(() -> Optional.ofNullable(ConfigProvider.getConfig().getValue("analyzer.technology-target", String.class)))
+            .orElseThrow(() -> new RuntimeException("Target technology for migration is requiered but not configured"));
 
         // Log resolved paths for debugging
         logger.infof("📋 Jdt-ls path: %s", jdtLsPath);

--- a/migration-tool/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
+++ b/migration-tool/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
@@ -36,14 +36,12 @@ public class AnalyzeCommand implements Runnable {
         index = "0",
         description = "Path to the Java project to analyze"
     )
-    @ConfigProperty(name = "analyzer.app.path", defaultValue = "./applications/spring-boot-todo-app")
     public String appPath;
 
     @CommandLine.Option(
         names = {"-r", "--rules"},
         description = "Path to rules directory (default: from config)"
     )
-    @ConfigProperty(name = "analyzer.rules.path", defaultValue = "./rules")
     public String rulesPath;
 
     @CommandLine.Option(
@@ -51,7 +49,6 @@ public class AnalyzeCommand implements Runnable {
         description = "Path to JDT-LS installation (default: from config)",
         required = false
     )
-    @ConfigProperty(name = "analyzer.jdt.ls.path", defaultValue = "./jdt/konveyor-jdtls")
     public String jdtLsPath;
 
     @CommandLine.Option(
@@ -59,11 +56,7 @@ public class AnalyzeCommand implements Runnable {
         description = "Path to JDT workspace directory (default: from config)",
         required = false
     )
-    @ConfigProperty(name = "analyzer.jdt.workspace.path", defaultValue = "./jdt")
     public String jdtWorkspace;
-
-    @ConfigProperty(name = "analyzer.jdt.ls.command", defaultValue = "java.project.getAll")
-    public String lsCommand;
 
     @CommandLine.Option(
         names = {"-v", "--verbose"},
@@ -81,14 +74,12 @@ public class AnalyzeCommand implements Runnable {
         names = {"-s","--source"},
         description = "Source technology to consider for analysis"
     )
-    @ConfigProperty(name = "analyzer.technology.source")
     public String source;
 
     @CommandLine.Option(
         names = {"-t","--target"},
         description = "Target technology to consider for analysis"
     )
-    @ConfigProperty(name = "analyzer.technology.target")
     public String target;
 
     @Override

--- a/migration-tool/src/main/resources/application.properties
+++ b/migration-tool/src/main/resources/application.properties
@@ -1,15 +1,21 @@
 # JDT Language Server Configuration
-analyzer.jdt-ls-command=io.konveyor.tackle.ruleEntry
-analyzer.jdt-ls-path=../jdt/konveyor-jdtls
-analyzer.jdt-workspace-path=../jdt
+analyzer.jdt-ls-command=${jdt.tls.command:io.konveyor.tackle.ruleEntry}
+analyzer.jdt-ls-path=${jdt.tls.path:../jdt/konveyor-jdtls}
+analyzer.jdt-workspace-path=${jdt.wks:../jdt}
 
 # Rules jdtLSConfiguration
-analyzer.rules-path=../cookbook/rules
+analyzer.rules-path=${rules.path:../cookbook/rules}
 
 # Application to scan
-analyzer.app-path=../applications/spring-boot-todo-app/
-analyzer.technology.source=springboot
-analyzer.technology.target=quarkus
+analyzer.technology-source=${tech.source:springboot}
+analyzer.technology-target=${tech.target:quarkus}
+
+#jdt.tls.path=/path/from/properties
+#jdt.wks=custom-properties-workspace
+#jdt.tls.command=java.project.getAll
+#rules.path=rules/from/properties
+#tech.source=micronaut
+#tech.target=springboot
 
 # Migration provider configuration: manual, ai, openrewrite
 migration.provider=openrewrite


### PR DESCRIPTION
- Replace mixed @ConfigProperty/@CommandLine annotations with explicit precedence handling
- CLI arguments now properly override application.properties values
- Add fallback chain: CLI > env vars > system properties > application.properties
