### PR TITLE
Add the missing setter field for matchResults

### DIFF
--- a/migration-cli/src/main/java/dev/snowdrop/analyze/model/MigrationTask.java
+++ b/migration-cli/src/main/java/dev/snowdrop/analyze/model/MigrationTask.java
@@ -8,9 +8,13 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class MigrationTask {
 	private Rule rule;
-	private List<SymbolInformation> lsResults;
-	private List<Match> matchResults;
 	private Rule.Instruction instruction;
+	private List<Match> matchResults;
+
+	@Deprecated
+	private List<SymbolInformation> lsResults;
+	@Deprecated
+	private List<Match> rewriteResults;
 
 	public MigrationTask() {
 	}
@@ -25,11 +29,6 @@ public class MigrationTask {
 		return this;
 	}
 
-	public MigrationTask withLsResults(List<SymbolInformation> lsResults) {
-		this.lsResults = lsResults;
-		return this;
-	}
-
 	public MigrationTask withMatchResults(List<Match> matchResults) {
 		this.matchResults = matchResults;
 		return this;
@@ -39,10 +38,28 @@ public class MigrationTask {
 		return rule;
 	}
 
+	public List<Match> getMatchResults() {
+		return matchResults;
+	}
+
+	@Deprecated
+	public MigrationTask withLsResults(List<SymbolInformation> lsResults) {
+		this.lsResults = lsResults;
+		return this;
+	}
+
+	@Deprecated
+	public MigrationTask withRewriteResults(List<Match> rewriteResults) {
+		this.rewriteResults = rewriteResults;
+		return this;
+	}
+
+	@Deprecated
 	public List<SymbolInformation> getLsResults() {
 		return lsResults;
 	}
 
+	@Deprecated
 	public List<Match> getRewriteResults() {
 		return matchResults;
 	}

--- a/migration-cli/src/main/java/dev/snowdrop/analyze/services/ResultsService.java
+++ b/migration-cli/src/main/java/dev/snowdrop/analyze/services/ResultsService.java
@@ -13,6 +13,7 @@ import dev.snowdrop.analyze.model.html.Cell;
 import dev.snowdrop.analyze.model.html.Row;
 import dev.snowdrop.analyze.utils.TerminalUtils;
 import dev.snowdrop.commands.AnalyzeCommand;
+import dev.snowdrop.transform.model.MigrationTasksExport;
 import io.quarkus.qute.*;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -280,10 +281,14 @@ public class ResultsService {
 			if (aTask.getLsResults() != null && !aTask.getLsResults().isEmpty()) {
 				queryResults = aTask.getLsResults();
 			}
-			*/
 
 			if (aTask.getRewriteResults() != null && !aTask.getRewriteResults().isEmpty()) {
 				queryResults = aTask.getRewriteResults();
+			}
+			*/
+
+			if (aTask.getMatchResults() != null && !aTask.getMatchResults().isEmpty()) {
+				queryResults = aTask.getMatchResults();
 			}
 
 			String hasQueryResults = queryResults.isEmpty() ? "No" : "Yes";
@@ -298,7 +303,7 @@ public class ResultsService {
 					Match match = queryResults.get(i);
 
 					String resultDetails = formatMatchResult(match);
-					if (resultDetails.length() > 0) {
+					if (!resultDetails.isEmpty()) {
 						allResultsDetails.append(resultDetails);
 					} else {
 						allResultsDetails.append("No results found");
@@ -390,8 +395,8 @@ public class ResultsService {
 					.withLocale(Locale.getDefault());
 			String dateTimeformated = LocalDateTime.now().format(formatter);
 
-			AnalyzeCommand.MigrationTasksExport exportData = new AnalyzeCommand.MigrationTasksExport(
-					"Migration Analysis Results", config.appPath(), dateTimeformated, tasks);
+			MigrationTasksExport exportData = new MigrationTasksExport("Migration Analysis Results", config.appPath(),
+					dateTimeformated, tasks);
 
 			ObjectMapper objectMapper = new ObjectMapper();
 			objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/migration-cli/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
+++ b/migration-cli/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
@@ -178,10 +178,4 @@ public class AnalyzeCommand implements Runnable {
 		Thread.sleep(2000);
 	}
 
-	// Data structure for JSON export
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	public record MigrationTasksExport(String title, String projectPath, String timestamp,
-			Map<String, MigrationTask> migrationTasks) {
-	}
-
 }


### PR DESCRIPTION
- Add the missing setter field for MigrationTask => `matchResults`. 
- Deprecate: rewriteResults and lsResults.
- Fix Issue #120