### PR TITLE
Add new recipes to migrate SB Todo to Quarkus

### DIFF
--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/AddPlugin2.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/AddPlugin2.java
@@ -39,12 +39,12 @@ public class AddPlugin2 extends Recipe {
 	@Nullable
 	String dependencies;
 
-    @Language("xml")
+	@Language("xml")
 	@Option(displayName = "Executions", description = "Optional executions provided as raw XML.", example = "<executions><execution><phase>generate-sources</phase><goals><goal>add-source</goal></goals></execution></executions>", required = false)
 	@Nullable
 	String executions;
 
-    @Language("xml")
+	@Language("xml")
 	@Option(displayName = "Extensions", description = "Optional extensions provided as raw XML.", example = "<extensions>true</extensions>", required = false)
 	@Nullable
 	String extensions;

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/ChangeMethodReturnType.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/ChangeMethodReturnType.java
@@ -1,0 +1,89 @@
+package dev.snowdrop.openrewrite.recipe.spring;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.jspecify.annotations.Nullable;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeMethodReturnType extends Recipe {
+
+	@Option(displayName = "Method pattern", description = MethodMatcher.METHOD_PATTERN_DESCRIPTION, example = "org.mockito.Matchers anyVararg()")
+	String methodPattern;
+
+	@Option(displayName = "New method invocation return type", description = "The fully qualified new return type of method invocation.", example = "long")
+	String newReturnType;
+
+	@Override
+	public String getDisplayName() {
+		return "Change method invocation return type";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Changes the return type of a method invocation.";
+	}
+
+	@Override
+	public Validated<Object> validate() {
+		return super.validate().and(MethodMatcher.validate(methodPattern));
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+		return new JavaIsoVisitor<ExecutionContext>() {
+			private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+
+			@Override
+			public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+				J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+				JavaType.Method type = m.getMethodType();
+
+				if (methodMatcher.matches(m.getMethodType())) {
+					System.out.println("========== BEFORE ==========");
+					System.out.printf("Method name: %s \n", m.getSimpleName());
+					System.out.printf("Method modifiers: %s \n", m.getModifiers());
+					System.out.printf("Return Type: %s \n", m.getType());
+					System.out.printf("Declaring type: %s \n", m.getMethodType().getDeclaringType());
+
+					type = type.withReturnType(JavaType.buildType(newReturnType));
+					m = m.withMethodType(type);
+
+					System.out.println("========== AFTER ==========");
+					System.out.printf("Method name: %s \n", m.getSimpleName());
+					System.out.printf("Method modifiers: %s \n", m.getModifiers());
+					System.out.printf("Return Type: %s \n", m.getType());
+					System.out.printf("Declaring type: %s \n", m.getMethodType().getDeclaringType());
+				}
+				return m;
+			}
+
+			/*
+			@Override
+			public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+			    J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+			    JavaType.Method type = m.getMethodType();
+
+			    if (methodMatcher.matches(m.getMethodType())) {
+			        System.out.printf("Method name: %s \n",m.getSimpleName());
+			        System.out.printf("Method type arguments: %s \n",m.getArguments());
+			        System.out.printf("Return Type: %s \n",m.getType());
+			        System.out.printf("Flags: %s \n",m.getMethodType().getFlags());
+			        System.out.printf("Declaring type: %s \n",m.getMethodType().getDeclaringType());
+
+			        return m.withMethodType(type.withReturnType(JavaType.buildType(newReturnType)));
+			    }
+
+			    return m;
+			}
+
+			 */
+		};
+	}
+}

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/RemoveMethodParameters.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/RemoveMethodParameters.java
@@ -34,13 +34,13 @@ public class RemoveMethodParameters extends Recipe {
 		@Override
 		public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
 			if (methodToSearch.contains(method.getSimpleName())) {
-                if (!method.getParameters().isEmpty()) {
-                    // Remove the parameters of the method.
-                    // Example foo(String bar) => foo()
-                    return method.withParameters(Collections.emptyList());
-                }
-            }
-            return super.visitMethodDeclaration(method, ctx);
+				if (!method.getParameters().isEmpty()) {
+					// Remove the parameters of the method.
+					// Example foo(String bar) => foo()
+					return method.withParameters(Collections.emptyList());
+				}
+			}
+			return super.visitMethodDeclaration(method, ctx);
 		}
 	}
 }

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/ReplaceMethodBodyContent.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/openrewrite/recipe/spring/ReplaceMethodBodyContent.java
@@ -10,37 +10,36 @@ import org.openrewrite.java.tree.J;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class ReplaceMethodBodyContent extends Recipe {
-    @Override
-    public @NlsRewrite.DisplayName String getDisplayName() {
-        return "Replace method body content";
-    }
+	@Override
+	public @NlsRewrite.DisplayName String getDisplayName() {
+		return "Replace method body content";
+	}
 
-    @Override
-    public @NlsRewrite.Description String getDescription() {
-        return "Replace method body content.";
-    }
+	@Override
+	public @NlsRewrite.Description String getDescription() {
+		return "Replace method body content.";
+	}
 
-    @Option(displayName = "Name of the method to search", description = "Name of the method where we will remove the parameters")
-    String methodToSearch;
+	@Option(displayName = "Name of the method to search", description = "Name of the method where we will remove the parameters")
+	String methodToSearch;
 
-    @Option(displayName = "String replaced", description = "String replaced")
-    String replacement;
+	@Option(displayName = "String replaced", description = "String replaced")
+	String replacement;
 
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new MethodBodyMainVisitor();
-    }
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new MethodBodyMainVisitor();
+	}
 
-    private class MethodBodyMainVisitor extends JavaIsoVisitor<ExecutionContext> {
+	private class MethodBodyMainVisitor extends JavaIsoVisitor<ExecutionContext> {
 
-        @Override
-        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-            JavaTemplate t = JavaTemplate.builder(replacement)
-                .build();
-            if (methodToSearch.contains(method.getSimpleName())) {
-                return t.apply(getCursor(), method.getCoordinates().replaceBody());
-            }
-            return super.visitMethodDeclaration(method, ctx);
-        }
-    }
+		@Override
+		public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+			JavaTemplate t = JavaTemplate.builder(replacement).build();
+			if (methodToSearch.contains(method.getSimpleName())) {
+				return t.apply(getCursor(), method.getCoordinates().replaceBody());
+			}
+			return super.visitMethodDeclaration(method, ctx);
+		}
+	}
 }

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/quarkus/spring/ChangeMethodContentTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/quarkus/spring/ChangeMethodContentTest.java
@@ -4,7 +4,6 @@ import dev.snowdrop.openrewrite.recipe.spring.RemoveMethodParameters;
 import dev.snowdrop.openrewrite.recipe.spring.ReplaceMethodBodyContent;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.CompositeRecipe;
-import org.openrewrite.java.ChangeMethodInvocationReturnType;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
@@ -21,42 +20,38 @@ public class ChangeMethodContentTest implements RewriteTest {
 	@Test
 	void replaceMethodBodyContent() {
 		rewriteRun(spec -> spec.recipe(new ReplaceMethodBodyContent("generateMessage", replacement))
-			.expectedCyclesThatMakeChanges(1).cycles(1),
-            java("""
-				public class TaskController {
-				  public String viewHome() {
-				    return generateMessage();
-				  }
-				  String generateMessage() {
-				    return "Hi";
-				  }
-				}
-				""",
-                """
-				public class TaskController {
-				  public String viewHome() {
-				    return generateMessage();
-				  }
-				  String generateMessage() {
-				      var msg = "Hi from me";
-				      return msg;
-				  }
-				}
-				"""));
+				.expectedCyclesThatMakeChanges(1).cycles(1), java("""
+						public class TaskController {
+						  public String viewHome() {
+						    return generateMessage();
+						  }
+						  String generateMessage() {
+						    return "Hi";
+						  }
+						}
+						""", """
+						public class TaskController {
+						  public String viewHome() {
+						    return generateMessage();
+						  }
+						  String generateMessage() {
+						      var msg = "Hi from me";
+						      return msg;
+						  }
+						}
+						"""));
 	}
 
 	@Test
 	void replaceMethodSignature() {
-		rewriteRun(spec -> spec.recipe(new CompositeRecipe(List.of(
-                new RemoveMethodParameters("viewHome()"),
-                new ReplaceMethodBodyContent("addAttribute()", "return new StringBuilder().append(\"Hi. This is me !);"),
-                new ChangeMethodInvocationReturnType("TaskController addAttribute(..)","java.lang.StringBuilder")
-            )))
-			.expectedCyclesThatMakeChanges(1).cycles(1),
-            java("""
+		rewriteRun(spec -> spec
+				.recipe(new CompositeRecipe(List.of(new RemoveMethodParameters("viewHome()"),
+						new ReplaceMethodBodyContent("addAttribute()",
+								"return new StringBuilder().append(\"Hi. This is me !\").toString();"))))
+				.expectedCyclesThatMakeChanges(1).cycles(1), java("""
 						public class TaskController {
 						  public String viewHome(String msg) {
-						    return addAttribute("task", new Object());
+						    String res = addAttribute("task", new Object());
 						  }
 						  String addAttribute(String name, Object value) {
 						    return "Hi";
@@ -65,10 +60,10 @@ public class ChangeMethodContentTest implements RewriteTest {
 						""", """
 						  public class TaskController {
 						    public String viewHome() {
-						      return addAttribute("task", new Object());
+						      String res = addAttribute("task", new Object());
 						    }
-						    StringBuilder addAttribute(String name, Object value) {
-						        return new StringBuilder().append("Hi. This is me !);
+						    String addAttribute(String name, Object value) {
+						        return new StringBuilder().append("Hi. This is me !").toString();
 						    }
 						  }
 						"""));

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/quarkus/spring/ReplaceMethodReturnTypeTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/openrewrite/quarkus/spring/ReplaceMethodReturnTypeTest.java
@@ -1,0 +1,103 @@
+package dev.snowdrop.openrewrite.quarkus.spring;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.java.ChangeMethodInvocationReturnType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class ReplaceMethodReturnTypeTest implements RewriteTest {
+
+	@Test
+	@DisplayName("Replace the type of the variable calling a method.")
+	void replaceReturnTypeOfMethodInvoked() {
+		rewriteRun(spec -> spec
+				.recipe(new CompositeRecipe(
+						List.of(new ChangeMethodInvocationReturnType("TaskController addMessage(..)", "Object"))))
+				.expectedCyclesThatMakeChanges(1).cycles(1), java("""
+						public class TaskController {
+						  public String viewHome(String msg) {
+						    String res = addMessage(msg);
+						  }
+						  String addMessage(String msg) {
+						      return new StringBuilder().append("Hi").append(msg).toString();
+						  }
+						}
+						""", """
+						  public class TaskController {
+						    public String viewHome(String msg) {
+						      Object res = addMessage(msg);
+						    }
+						    String addMessage(String msg) {
+						        return new StringBuilder().append("Hi").append(msg).toString();
+						    }
+						  }
+						"""));
+	}
+
+	@Test
+	@Disabled // This test is disabled due to this error: https://github.com/openrewrite/rewrite/issues/6379
+	@DisplayName("Replace the return type of a method.")
+	void replaceReturnTypeOfMethodDeclared() {
+		String methodPattern = "TaskController addMessage(..)";
+		String newReturnType = "Object";
+
+		rewriteRun(spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+			final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+			static boolean methodUpdated = false;
+
+			@Override
+			public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+				J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+				if (methodMatcher.matches(m.getMethodType())) {
+					System.out.println("========== BEFORE ==========");
+					System.out.printf("Method name: %s \n", m.getSimpleName());
+					System.out.printf("Method modifiers: %s \n", m.getModifiers());
+					System.out.printf("Return Type: %s \n", m.getType());
+					System.out.printf("Declaring type: %s \n", m.getMethodType().getDeclaringType());
+
+					JavaType.Method newType = m.getMethodType().withReturnType(JavaType.buildType(newReturnType));
+					m = m.withMethodType(newType).withName(m.getName().withType(newType));
+
+					System.out.println("========== AFTER ==========");
+					System.out.printf("Method name: %s \n", m.getSimpleName());
+					System.out.printf("Method modifiers: %s \n", m.getModifiers());
+					System.out.printf("New return Type: %s \n", m.getMethodType().getReturnType());
+					System.out.printf("Declaring type: %s \n", m.getMethodType().getDeclaringType());
+					methodUpdated = true;
+				}
+				return m;
+			}
+		})).expectedCyclesThatMakeChanges(1).cycles(1), java("""
+				public class TaskController {
+				  public String viewHome(String msg) {
+				    var res = addMessage(msg);
+				  }
+				  protected String addMessage(String msg) {
+				      return new StringBuilder().append("Hi").append(msg).toString();
+				  }
+				}
+				""", """
+				  public class TaskController {
+				    public String viewHome(String msg) {
+				      var res = addMessage(msg);
+				    }
+				    protected Object addMessage(String msg) {
+				        return new StringBuilder().append("Hi").append(msg).toString();
+				    }
+				  }
+				"""));
+	}
+}


### PR DESCRIPTION
- Add new recipes to migrate SB Todo to Quarkus
- The new recipes will be used to remove the parameter:
   - Remove the parameters of a method
   - Replace the content of the body of a method 
   - Change the return type of a method. Don't work yet due to this issue: https://github.com/openrewrite/rewrite/issues/6379