### PR TITLE
Generate the json report no matter which output format the user selected

### DIFF
--- a/migration-cli/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
+++ b/migration-cli/src/main/java/dev/snowdrop/commands/AnalyzeCommand.java
@@ -164,13 +164,16 @@ public class AnalyzeCommand implements Runnable {
 				config.targetTechnology());
 		resultsService.showCsvTable(tableData);
 
-		// Export rules, results and migration instructions
-		String output = Objects.requireNonNullElse(config.output(), "json");
+		// Always generate the json report as it is needed to perform the transformation step
+		resultsService.exportAsJson(config, tasks);
 
-		switch (output) {
-			case "html" -> resultsService.exportAsHtml(config, tableData);
-			case "csv" -> resultsService.exportAsCsv(config, tableData);
-			default -> resultsService.exportAsJson(config, tasks);
+		// Export also the report using the selected format if the user used the option: -o, --output.
+		if (config.output() != null && !config.output().isEmpty()) {
+			switch (output) {
+				case "html" -> resultsService.exportAsHtml(config, tableData);
+				case "csv" -> resultsService.exportAsCsv(config, tableData);
+				default -> logger.warnf("The format selected to export the report is unknown: %s", output);
+			}
 		}
 
 		logger.infof("⏳ Waiting for commands to complete...");

--- a/migration-cli/src/main/java/dev/snowdrop/commands/TransformCommand.java
+++ b/migration-cli/src/main/java/dev/snowdrop/commands/TransformCommand.java
@@ -121,7 +121,7 @@ public class TransformCommand implements Runnable {
 	 */
 	private Optional<Path> findLatestAnalysingReportJson(Path projectPath) {
 		FileSystem fs = FileSystems.getDefault();
-		PathMatcher matcher = fs.getPathMatcher("glob:analysing-*-report_*");
+		PathMatcher matcher = fs.getPathMatcher("glob:analysing-*-report_*.json");
 
 		try (Stream<Path> stream = Files.list(projectPath)) {
 			return stream.filter(Files::isRegularFile).filter(path -> matcher.matches(path.getFileName()))


### PR DESCRIPTION
- Generate the json report no matter which output format the user selected. 
- Filter the report files to only got the json. 
- #143

PR tested without an output format or with, with also wrong output format