### PR TITLE
Remove the hard coded version of the rewrite maven plugin

### DIFF
--- a/migration-cli/src/main/java/dev/snowdrop/mtool/commands/AnalyzeCommand.java
+++ b/migration-cli/src/main/java/dev/snowdrop/mtool/commands/AnalyzeCommand.java
@@ -122,8 +122,12 @@ public class AnalyzeCommand implements Runnable {
 				.orElseThrow(() -> new RuntimeException(
 						"Command to be executed against the LS server is required but not configured"));
 
+		String openRewriteMavenPluginVersion = Optional
+				.ofNullable(ConfigProvider.getConfig().getValue("openrewrite.maven-plugin.version", String.class))
+				.orElseThrow(() -> new RuntimeException("Openrewrite maven plugin version not define"));
+
 		Config config = new Config(appPathString, rulesPath, sourceTechnology, targetTechnology, jdtLsPathString,
-				jdtWksString, lsCmd, verbose, output, scanner);
+				jdtWksString, lsCmd, verbose, output, scanner, openRewriteMavenPluginVersion);
 
 		// Log resolved paths for debugging
 		logger.infof("📋 Jdt-ls path: %s", jdtLsPath);
@@ -132,6 +136,7 @@ public class AnalyzeCommand implements Runnable {
 		logger.infof("📋 Application path: %s", appPath);
 		logger.infof("📋 Source technology: %s", sourceTechnology);
 		logger.infof("📋 Target technology: %s", targetTechnology);
+		logger.infof("📋 Openrewrite maven plugin version: %s", openRewriteMavenPluginVersion);
 		return config;
 	}
 

--- a/migration-cli/src/main/java/dev/snowdrop/mtool/commands/TransformCommand.java
+++ b/migration-cli/src/main/java/dev/snowdrop/mtool/commands/TransformCommand.java
@@ -48,7 +48,7 @@ public class TransformCommand implements Runnable {
 	@ConfigProperty(name = "migration.provider.openrewrite.composite-recipe-name")
 	private String compositeRecipeName;
 
-	@ConfigProperty(name = "migration.provider.openrewrite.plugin.version")
+	@ConfigProperty(name = "openrewrite.maven-plugin.version")
 	private String openRewriteMavenPluginVersion;
 
 	@Inject

--- a/migration-cli/src/main/resources/application.properties
+++ b/migration-cli/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+openrewrite.maven-plugin.version=6.27.0
+
 # JDT Language Server Configuration
 analyzer.jdt-ls-command=${jdt.tls.command:io.konveyor.tackle.ruleEntry}
 analyzer.jdt-ls-path=${jdt.tls.path:../jdt/konveyor-jdtls}
@@ -20,7 +22,6 @@ analyzer.technology-target=${tech.target:quarkus}
 # Migration provider configuration: manual, ai, openrewrite
 migration.provider=openrewrite
 migration.provider.openrewrite.composite-recipe-name=dev.snowdrop.openrewrite.java.SpringToQuarkus
-migration.provider.openrewrite.plugin.version=6.22.1
 
 # Quarkus banner and log
 quarkus.banner.enabled=false

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>model</artifactId>
     <name>Migration Tool :: Model</name>
 
+    <properties>
+        <!-- Skip to execute quarkus maven plugin -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
+
     <dependencies>
         <!-- Logging -->
         <dependency>

--- a/model/src/main/java/dev/snowdrop/mtool/model/analyze/Config.java
+++ b/model/src/main/java/dev/snowdrop/mtool/model/analyze/Config.java
@@ -3,5 +3,6 @@ package dev.snowdrop.mtool.model.analyze;
 import java.nio.file.Path;
 
 public record Config(String appPath, Path rulesPath, String sourceTechnology, String targetTechnology, String jdtLsPath,
-		String jdtWks, String lsCmd, boolean verbose, String output, String scanner) {
+		String jdtWks, String lsCmd, boolean verbose, String output, String scanner,
+		String openRewriteMavenPluginVersion) {
 }

--- a/openrewrite-recipes/pom.xml
+++ b/openrewrite-recipes/pom.xml
@@ -15,6 +15,9 @@
 
     <properties>
         <rewrite-maven-plugin.version>6.27.0</rewrite-maven-plugin.version>
+
+        <!-- Skip to execute quarkus maven plugin -->
+        <quarkus.build.skip>true</quarkus.build.skip>
     </properties>
 
     <dependencies>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>parser</artifactId>
     <name>Migration Tool :: Query parser</name>
 
+    <properties>
+        <!-- Skip to execute quarkus maven plugin -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.snowdrop.mtool</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.30.6</quarkus.platform.version>
+        <quarkus.build.skip>false</quarkus.build.skip>
 
         <openrewrite-recipe-bom.version>3.22.0</openrewrite-recipe-bom.version>
         <spring-boot.version>4.0.1</spring-boot.version>
@@ -43,6 +44,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
 
         <skipITs>true</skipITs>
+        <formatterStyleFile>${project.parent.basedir}/formatter-config.xml</formatterStyleFile>
 
     </properties>
 
@@ -207,6 +209,9 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
+                <configuration>
+                    <skip>${quarkus.build.skip}</skip>
+                </configuration>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -247,7 +252,7 @@
                 <artifactId>formatter-maven-plugin</artifactId>
                 <version>${maven-formatter-plugin.version}</version>
                 <configuration>
-                    <configFile>${maven.multiModuleProjectDirectory}/formatter-config.xml</configFile>
+                    <configFile>${formatterStyleFile}</configFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/scanner/pom.xml
+++ b/scanner/pom.xml
@@ -15,6 +15,9 @@
 
     <properties>
         <maven.version>3.9.12</maven.version>
+
+        <!-- Skip to execute quarkus maven plugin -->
+        <quarkus.build.skip>true</quarkus.build.skip>
     </properties>
 
     <dependencies>

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
@@ -73,7 +73,7 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 		logger.debugf("Recipe generated: %s", yamlRecipe);
 
 		// Execute the maven rewrite goal command
-		boolean succeed = execOpenrewriteMvnPlugin(config.appPath(), true, yamlRecipe);
+		boolean succeed = execOpenrewriteMvnPlugin(config, true, yamlRecipe);
 		if (!succeed) {
 			logger.warnf("Failed to execute the maven command");
 			return new ArrayList<>();
@@ -188,10 +188,10 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 		return yaml.toString();
 	}
 
-	private boolean execOpenrewriteMvnPlugin(String appProjectPath, boolean verbose, String yamlRecipe) {
+	private boolean execOpenrewriteMvnPlugin(Config config, boolean verbose, String yamlRecipe) {
 		// Copy the rewrite yaml file under the project to scan
 		String rewriteYamlName = "rewrite.yml";
-		Path path = Paths.get(appProjectPath);
+		Path path = Paths.get(config.appPath());
 		Path yamlFilePath = path.resolve(rewriteYamlName);
 
 		try {
@@ -215,7 +215,7 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 			command.add("-B");
 			command.add("-e");
 			command.add(String.format("%s:%s:%s:%s", MAVEN_OPENREWRITE_PLUGIN_GROUP, MAVEN_OPENREWRITE_PLUGIN_ARTIFACT,
-					"6.24.0", "dryRun"));
+					config.openRewriteMavenPluginVersion(), "dryRun"));
 			command.add(String.format("-Drewrite.activeRecipes=%s", "dev.snowdrop.openrewrite.MatchConditions"));
 			command.add("-Drewrite.recipeArtifactCoordinates=" + gavs);
 			command.add("-Drewrite.exportDatatables=true");

--- a/scanner/src/test/java/dev/snowdrop/mtool/scanner/CodeScannerServiceTest.java
+++ b/scanner/src/test/java/dev/snowdrop/mtool/scanner/CodeScannerServiceTest.java
@@ -37,7 +37,7 @@ class CodeScannerServiceTest {
 	void setup() throws IOException {
 		tempDir = Files.createTempDirectory("rewrite-test");
 		config = new Config(tempDir.toString(), Paths.get("./rules"), "springboot", "quarkus", "./jdt/konveyor-jdtls",
-				"./jdt", "io.konveyor.tackle.ruleEntry", false, "json", "openrewrite");
+				"./jdt", "io.konveyor.tackle.ruleEntry", false, "json", "openrewrite", "6.27.0");
 		scanCommandExecutor = Mockito.mock(ScanCommandExecutor.class);
 		codeScannerService = new CodeScannerService(config, scanCommandExecutor);
 	}

--- a/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/BaseRulesTest.java
+++ b/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/BaseRulesTest.java
@@ -36,6 +36,6 @@ public class BaseRulesTest {
 	public Config createTestConfig(Path applicationToScan, Path rulesPath, String jdtls) {
 		return new Config(applicationToScan.toString(), rulesPath, "springboot", "quarkus",
 				Paths.get(jdtls, "konveyor-jdtls").toString(), jdtls, "io.konveyor.tackle.ruleEntry", false, "json",
-				null);
+				null, "6.27.0");
 	}
 }


### PR DESCRIPTION
- Remove the hard coded version of the rewrite maven plugin
- Use a new config property `openRewriteMavenPluginVersion` to set the value using the quarkus property:  `analyzer.openrewrite.maven-plugin.version`
- Set the version during init step 
- Fix #46

Can a test class also got a property from the src/main/resources/application.properties to avoid to also hard code the openrewrite maven plugin version with the test classes ? @aureamunoz 