### PR TITLE
Fix the jackson parsing issue of the settings.xml file using jackson 2.17

### DIFF
--- a/openrewrite-recipes/pom.xml
+++ b/openrewrite-recipes/pom.xml
@@ -17,6 +17,18 @@
         <rewrite-maven-plugin.version>6.27.0</rewrite-maven-plugin.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.17.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.openrewrite</groupId>
@@ -37,6 +49,14 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-templating</artifactId>
+        </dependency>
+
+        <!-- Jackson gav needed as we override jackson => 2.17.3-->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Spring Boot dependency need by Rewrite test and java parser -->

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/java/search/FindDependencyTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/java/search/FindDependencyTest.java
@@ -3,12 +3,14 @@ package dev.snowdrop.mtool.openrewrite.java.search;
 import dev.snowdrop.mtool.openrewrite.maven.search.FindDependency;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.maven.MavenParser;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
 // TODO: Test disabled due to the jackson parsing issue with settings.xml: https://github.com/openrewrite/rewrite/issues/4803
-@Disabled
+// @Disabled
 public class FindDependencyTest implements RewriteTest {
 
 	@Test


### PR DESCRIPTION
- Fix the jackson parsing issue of the `settings.xml` file using jackson 2.17 till rewrite fix it upstream.
- See: #196