### PR TITLE
Use the parent maven-resolver-provider pom

### DIFF
--- a/scanner/pom.xml
+++ b/scanner/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <maven.version>3.9.12</maven.version>
+        <maven-resolver.version>1.9.25</maven-resolver.version>
 
         <!-- Skip to execute quarkus maven plugin -->
         <quarkus.build.skip>true</quarkus.build.skip>
@@ -48,17 +49,8 @@
             <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
         </dependency>
 
-        <!-- Search maven dependency -->
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model-builder</artifactId>
-            <version>${maven.version}</version>
-        </dependency>
+        <!-- Search maven dependencies -->
+        <!-- Simplify the dependencies to be used first by using the maven-resolver pom before to move to 2.x -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-resolver-provider</artifactId>
@@ -66,24 +58,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-impl</artifactId>
-            <version>1.9.24</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-connector-basic</artifactId>
-            <version>2.0.14</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-http</artifactId>
-            <version>1.9.25</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <artifactId>maven-resolver-supplier</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <!-- OpenCSV for better CSV parsing and object binding -->

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/maven/RepositoryModelResolver.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/maven/RepositoryModelResolver.java
@@ -13,15 +13,11 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 
 import java.util.List;
 
@@ -91,10 +87,12 @@ public class RepositoryModelResolver implements ModelResolver {
 	}
 
 	private RepositorySystem newRepositorySystem() {
-		DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+		/*DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
 		locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
 		locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-		return locator.getService(RepositorySystem.class);
+		return locator.getService(RepositorySystem.class);*/
+		RepositorySystemSupplier supplier = new RepositorySystemSupplier();
+		return supplier.get();
 	}
 
 	private DefaultRepositorySystemSession newRepositorySystemSession(RepositorySystem system) {


### PR DESCRIPTION
- Use the parent maven-resolver-provider pom and dependencies defined to import what it is needed. 
- Add maven-resolver-supplier dependency as MavenRepositorySystemUtils.newServiceLocator() is deprecated