### PR TITLE
Added a new simple scenario: rule, FindSourceFiles recipe able to aut…

### DIFF
--- a/cookbook/rules/formating/autoformat.yml
+++ b/cookbook/rules/formating/autoformat.yml
@@ -1,0 +1,22 @@
+- category: mandatory
+  description: Format the Java code to respect best practices formating conventions
+  effort: 1
+  labels:
+    - konveyor.io/source=java
+    - konveyor.io/target=code-formated
+  message: "Automatic format the Java code"
+  ruleID: 000-java-format
+  when:
+    precondition: source.file is '**/*.java'
+    #- org.openrewrite.java.search.HasJavaVersion:
+    #  version: "[25,)"
+    #- org.openrewrite.FindSourceFiles:
+    #    filePattern: '**/beans.java'
+  instructions:
+    openrewrite:
+      - name: Format Java code using a standard comprehensive set of Java formatting recipes
+        description: Format Java code using a standard comprehensive set of Java formatting recipes.
+        recipeList:
+          - org.openrewrite.java.format.AutoFormat
+        gav:
+          - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/file/search/FindSourceFiles.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/file/search/FindSourceFiles.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.snowdrop.mtool.openrewrite.file.search;
+
+import dev.snowdrop.mtool.openrewrite.file.table.SourcesFiles;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.quark.Quark;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class FindSourceFiles extends Recipe {
+	transient SourcesFiles results = new SourcesFiles(this);
+
+	/**
+	 * ID of the matching tool needed to reconcile the records where a match took place
+	 */
+	@Option(displayName = "Match id", description = "ID of the matching tool needed to reconcile the records where a match took place", required = true)
+	public String matchId;
+
+	@Option(displayName = "File pattern", description = "A glob expression representing a file path to search for (relative to the project root). Blank/null matches all."
+			+ "Multiple patterns may be specified, separated by a semicolon `;`. "
+			+ "If multiple patterns are supplied any of the patterns matching will be interpreted as a match.", required = false, example = ".github/workflows/*.yml")
+	@Nullable
+	String filePattern;
+
+	@Override
+	public String getDisplayName() {
+		return "Find files";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Find files by source path. Paths are always interpreted as relative to the repository root.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new TreeVisitor<Tree, ExecutionContext>() {
+
+			@Override
+			public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+				if (tree instanceof SourceFile) {
+					SourceFile sourceFile = (SourceFile) tree;
+					Path sourcePath = sourceFile.getSourcePath();
+					if (matches(sourcePath)) {
+						results.insertRow(ctx,
+								new SourcesFiles.Row(matchId, sourcePath.toString(), tree.getClass().getSimpleName(),
+										sourceFile instanceof Quark || sourceFile.getCharset() == null
+												? null
+												: sourceFile.getCharset().toString()));
+						return SearchResult.found(sourceFile);
+					}
+				}
+				return tree;
+			}
+
+			String @Nullable [] filePatterns;
+
+			private boolean matches(Path sourcePath) {
+				if (filePatterns == null) {
+					filePatterns = Optional.ofNullable(filePattern).map(it -> it.split(";")).map(Arrays::stream)
+							.orElseGet(Stream::empty).map(String::trim).filter(StringUtils::isNotEmpty)
+							.map(FindSourceFiles::normalize).toArray(String[]::new);
+				}
+				return filePatterns.length == 0
+						|| Arrays.stream(filePatterns).anyMatch(pattern -> PathUtils.matchesGlob(sourcePath, pattern));
+			}
+		};
+	}
+
+	private static String normalize(String filePattern) {
+		if (filePattern.startsWith("./") || filePattern.startsWith(".\\")) {
+			return filePattern.substring(2);
+		} else if (filePattern.startsWith("/") || filePattern.startsWith("\\")) {
+			return filePattern.substring(1);
+		}
+		return filePattern;
+	}
+}

--- a/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/file/table/SourcesFiles.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/file/table/SourcesFiles.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.snowdrop.mtool.openrewrite.file.table;
+
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+public class SourcesFiles extends DataTable<SourcesFiles.Row> {
+
+	public SourcesFiles(Recipe recipe) {
+		super(recipe, "Source files that matched", "Source files that matched some criteria.");
+	}
+
+	@Value
+	public static class Row {
+		@Column(displayName = "Match ID", description = "ID of the matching tool used to reconcile the information.")
+		String matchId;
+
+		@Column(displayName = "Source path before the run", description = "The source path of the file before the run.")
+		String sourcePath;
+
+		@Column(displayName = "LST type", description = "The LST model type that the file is parsed as.")
+		String type;
+
+		@Column(displayName = "Character encoding", description = "The detected character encoding of the file")
+		String encoding;
+	}
+}

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/CodeScannerService.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/CodeScannerService.java
@@ -37,6 +37,7 @@ public class CodeScannerService {
 
 			if (preconditionResult.isMatchSucceeded()) {
 				logger.warnf("Precondition matched for rule %s: %s", rule.ruleID(), rule.when().precondition());
+				return preconditionResult;
 			}
 
 			if (!preconditionResult.isMatchSucceeded()) {


### PR DESCRIPTION
- Added a new simple scenario: rule, `FindSourceFiles` recipe able to `autoformat` a java project
- Fix the error as the `preconditionResult` was not returned when `precondition` succeeded

**Remark**: The composite yaml recipes created when we generate it to execute the `transform` command should be improved as today it will be always equal to the value defined here `migration.provider.openrewrite.composite-recipe-name=dev.snowdrop.openrewrite.java.SpringToQuarkus` 

**Question**: Should we use such a syntax to find java files `source.file is '**/*.java'` as when (pre)condition ? @aureamunoz 