### PR TITLE
Use rewrite client keeping the QueryScanner interface atm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <ascii-table.version>1.9.0</ascii-table.version>
         <jackson.version>2.18.0</jackson.version>
         <opencsv.version>5.12.0</opencsv.version>
+        <rewrite-client.version>0.1.1-SNAPSHOT</rewrite-client.version>
 
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven-formatter-plugin.version>2.29.0</maven-formatter-plugin.version>
@@ -132,6 +133,13 @@
                 <artifactId>opencsv</artifactId>
                 <version>${opencsv.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>dev.snowdrop.openrewrite</groupId>
+                <artifactId>rewrite-client</artifactId>
+                <version>${rewrite-client.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/scanner/pom.xml
+++ b/scanner/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>opencsv</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>dev.snowdrop.openrewrite</groupId>
+            <artifactId>rewrite-client</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Note that this uses a locally built of the rewrite-client. 
It's a draft, I haven't tested. I've just added the 'scafolding' code to make it work calling the rewrite-client. We need to adapt the response and all the front to display data coherently