### PR TITLE
Bump openrewrite BOM to 3.24.0

### DIFF
--- a/SCENARIO.md
+++ b/SCENARIO.md
@@ -160,7 +160,7 @@ public class TodoApplication implements QuarkusApplication {
           - spring.recipe.dev.snowdrop.mtool.openrewrite.AddQuarkusMavenPlugin
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.0-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.62.4
+          - org.openrewrite:rewrite-maven:8.73.0
 ```
 
 **Steps: 1, 2 and 3**

--- a/cookbook/rules/quarkus-spring-precondition/010-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus-spring-precondition/010-springboot-replace-bom-quarkus.yaml
@@ -43,8 +43,8 @@
           - org.openrewrite.quarkus.spring.RemoveSpringBootParent
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.0
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-maven:8.73.0
+          - org.openrewrite:rewrite-java:8.73.0
           - org.openrewrite.recipe:rewrite-java-dependencies:1.46.0
           - org.openrewrite.recipe:rewrite-spring-to-quarkus:0.3.1
 

--- a/cookbook/rules/quarkus-spring/010-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus-spring/010-springboot-replace-bom-quarkus.yaml
@@ -49,8 +49,8 @@
           - org.openrewrite.quarkus.spring.RemoveSpringBootParent
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.0
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-maven:8.73.0
+          - org.openrewrite:rewrite-java:8.73.0
           - org.openrewrite.recipe:rewrite-java-dependencies:1.46.0
           - org.openrewrite.recipe:rewrite-spring-to-quarkus:0.3.1
 

--- a/cookbook/rules/quarkus-spring/011-springboot-replace-dependency-jpa.yaml
+++ b/cookbook/rules/quarkus-spring/011-springboot-replace-dependency-jpa.yaml
@@ -33,8 +33,8 @@
               version: 3.26.4
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.0
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-maven:8.73.0
+          - org.openrewrite:rewrite-java:8.73.0
           - org.openrewrite.recipe:rewrite-java-dependencies:1.46.0
           - org.openrewrite.recipe:rewrite-spring-to-quarkus:0.3.1
 

--- a/cookbook/rules/quarkus-spring/012-springboot-replace-dependency-rest-web.yaml
+++ b/cookbook/rules/quarkus-spring/012-springboot-replace-dependency-rest-web.yaml
@@ -46,8 +46,8 @@
               version: 3.26.4
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.0
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-maven:8.73.0
+          - org.openrewrite:rewrite-java:8.73.0
           - org.openrewrite.recipe:rewrite-java-dependencies:1.46.0
           - org.openrewrite.recipe:rewrite-spring-to-quarkus:0.3.1
 

--- a/cookbook/rules/quarkus-spring/020-springboot-to-quarkus-rest-annotations.yaml
+++ b/cookbook/rules/quarkus-spring/020-springboot-to-quarkus-rest-annotations.yaml
@@ -27,4 +27,4 @@
               newFullyQualifiedTypeName: org.springframework.web.bind.annotation.RestController
         gav:
         - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-        - org.openrewrite:rewrite-java:8.71.0
+        - org.openrewrite:rewrite-java:8.73.0

--- a/cookbook/rules/quarkus-spring/030-springboot-to-quarkus-add-sql.yaml
+++ b/cookbook/rules/quarkus-spring/030-springboot-to-quarkus-add-sql.yaml
@@ -23,7 +23,7 @@
         description: Add a SQL file to create records
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-java:8.73.0
         recipeList:
           - org.openrewrite.text.CreateTextFile:
               relativeFileName: src/main/resources/import.sql

--- a/cookbook/rules/quarkus-spring/031-springboot-to-quarkus-replace-properties.yaml
+++ b/cookbook/rules/quarkus-spring/031-springboot-to-quarkus-replace-properties.yaml
@@ -23,7 +23,7 @@
         description: Replace the Spring properties with Quarkus equivalent
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-java:8.71.0
+          - org.openrewrite:rewrite-java:8.73.0
         recipeList:
           - org.openrewrite.properties.ChangePropertyKey:
               oldPropertyKey: spring.datasource.url

--- a/cookbook/rules/quarkus-spring/041-springboot-to-quarkus-rest-get-tasks.yaml
+++ b/cookbook/rules/quarkus-spring/041-springboot-to-quarkus-rest-get-tasks.yaml
@@ -34,4 +34,4 @@
               newReturnType: "org.springframework.http.ResponseEntity<List<Task>>"
         gav:
         - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-        - org.openrewrite:rewrite-java:8.71.0
+        - org.openrewrite:rewrite-java:8.73.0

--- a/cookbook/rules/quarkus-spring/042-springboot-to-quarkus-redirect.yaml
+++ b/cookbook/rules/quarkus-spring/042-springboot-to-quarkus-redirect.yaml
@@ -35,4 +35,4 @@
               newException: java.net.URISyntaxException
         gav:
         - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-        - org.openrewrite:rewrite-java:8.71.0
+        - org.openrewrite:rewrite-java:8.73.0

--- a/cookbook/rules/quarkus/001-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus/001-springboot-replace-bom-quarkus.yaml
@@ -46,7 +46,7 @@
           - dev.snowdrop.mtool.openrewrite.recipe.AddQuarkusMavenPlugin
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.02.4
+          - org.openrewrite:rewrite-maven:8.73.0
 
 
 

--- a/migration-cli/src/main/resources/application.properties
+++ b/migration-cli/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-openrewrite.maven-plugin.version=6.27.0
+openrewrite.maven-plugin.version=6.29.0
 
 # JDT Language Server Configuration
 analyzer.jdt-ls-command=${jdt.tls.command:io.konveyor.tackle.ruleEntry}

--- a/openrewrite-recipes/pom.xml
+++ b/openrewrite-recipes/pom.xml
@@ -14,7 +14,7 @@
     <name>Migration Tool :: Openrewrite recipes</name>
 
     <properties>
-        <rewrite-maven-plugin.version>6.27.0</rewrite-maven-plugin.version>
+        <rewrite-maven-plugin.version>6.29.0</rewrite-maven-plugin.version>
 
         <!-- Skip to execute quarkus maven plugin -->
         <quarkus.build.skip>true</quarkus.build.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <quarkus.platform.version>3.30.6</quarkus.platform.version>
         <quarkus.build.skip>false</quarkus.build.skip>
 
-        <openrewrite-recipe-bom.version>3.22.0</openrewrite-recipe-bom.version>
+        <openrewrite-recipe-bom.version>3.24.0</openrewrite-recipe-bom.version>
         <spring-boot.version>4.0.1</spring-boot.version>
         <org.eclipse.lsp4j.version>0.24.0</org.eclipse.lsp4j.version>
         <lombok.version>1.18.42</lombok.version>

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
@@ -283,9 +283,11 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 			throw new IllegalStateException("recipeList must contain rawMap");
 		}
 
-		// Recipe's jar files
-		String gavs = "org.openrewrite:rewrite-java:8.71.0,"
-				+ "org.openrewrite.recipe:rewrite-java-dependencies:1.49.0,"
+		// Recipe's jar files declared within the openrewrite pom
+		// Bom of the recipe: https://repo.maven.apache.org/maven2/org/openrewrite/recipe/rewrite-recipe-bom/3.24.0/rewrite-recipe-bom-3.24.0.pom
+		// Bom of the modules of rewrite: https://repo.maven.apache.org/maven2/org/openrewrite/rewrite-bom/8.73.0/rewrite-bom-8.73.0.pom
+		String gavs = "org.openrewrite:rewrite-java:8.73.0,"
+				+ "org.openrewrite.recipe:rewrite-java-dependencies:1.51.0,"
 				+ "dev.snowdrop.mtool:openrewrite-recipes:1.0.4";
 		Map<String, Map<String, String>> recipeMap = (Map<String, Map<String, String>>) first;
 
@@ -462,7 +464,7 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 		}
 
 		// Recipe's jar files
-		String gavs = "org.openrewrite:rewrite-java:8.65.0,"
+		String gavs = "org.openrewrite:rewrite-java:8.73.0,"
 				+ "org.openrewrite.recipe:rewrite-java-dependencies:1.44.0,"
 				+ "dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT";
 

--- a/scanner/src/test/java/dev/snowdrop/mtool/scanner/CodeScannerServiceTest.java
+++ b/scanner/src/test/java/dev/snowdrop/mtool/scanner/CodeScannerServiceTest.java
@@ -37,7 +37,7 @@ class CodeScannerServiceTest {
 	void setup() throws IOException {
 		tempDir = Files.createTempDirectory("rewrite-test");
 		config = new Config(tempDir.toString(), Paths.get("./rules"), "springboot", "quarkus", "./jdt/konveyor-jdtls",
-				"./jdt", "io.konveyor.tackle.ruleEntry", false, "json", "openrewrite", "6.27.0");
+				"./jdt", "io.konveyor.tackle.ruleEntry", false, "json", "openrewrite", "6.29.0");
 		scanCommandExecutor = Mockito.mock(ScanCommandExecutor.class);
 		codeScannerService = new CodeScannerService(config, scanCommandExecutor);
 	}

--- a/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/BaseRulesTest.java
+++ b/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/BaseRulesTest.java
@@ -38,13 +38,13 @@ public class BaseRulesTest {
 
 	public Config createTestConfig(Path applicationToScan, Path rulesPath) {
 		return new Config(applicationToScan.toString(), rulesPath, "springboot", "quarkus", "", "",
-				"io.konveyor.tackle.ruleEntry", false, "json", null, "6.27.0");
+				"io.konveyor.tackle.ruleEntry", false, "json", null, "6.29.0");
 	}
 
 	public Config createTestConfig(Path applicationToScan, Path rulesPath, String jdtls) {
 		return new Config(applicationToScan.toString(), rulesPath, "springboot", "quarkus",
 				Paths.get(jdtls, "konveyor-jdtls").toString(), jdtls, "io.konveyor.tackle.ruleEntry", false, "json",
-				null, "6.27.0");
+				null, "6.29.0");
 	}
 
 	public static void runCat(Path pathToFile) throws Exception {

--- a/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/RulesTest.java
+++ b/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/RulesTest.java
@@ -156,7 +156,7 @@ class RulesTest extends BaseRulesTest {
 				"Replace the SpringBoot parent dependency with Quarkus BOM within the pom.xml file.", null, // preconditions
 				null, // recipeList (aquí podrías añadir los recipes si los necesitas)
 				new String[]{"dev.snowdrop.mtool:openrewrite-recipes:1.0.0-SNAPSHOT",
-						"org.openrewrite:rewrite-maven:8.62.4"})};
+						"org.openrewrite:rewrite-maven:8.73.0"})};
 
 		Rule.Instruction instructions = new Rule.Instruction(aiInstructions, manualInstructions,
 				openrewriteInstructions);
@@ -193,7 +193,7 @@ class RulesTest extends BaseRulesTest {
 				"Replace the SpringBoot parent dependency with Quarkus BOM within the pom.xml file.", null, // preconditions
 				null, // recipeList (aquí podrías añadir los recipes si los necesitas)
 				new String[]{"dev.snowdrop.mtool:openrewrite-recipes:1.0.0-SNAPSHOT",
-						"org.openrewrite:rewrite-maven:8.62.4"})};
+						"org.openrewrite:rewrite-maven:8.73.0"})};
 
 		Rule.Instruction instructions = new Rule.Instruction(aiInstructions, manualInstructions,
 				openrewriteInstructions);
@@ -231,7 +231,7 @@ class RulesTest extends BaseRulesTest {
 				"Replace the SpringBoot parent dependency with Quarkus BOM within the pom.xml file.", null, // preconditions
 				null, // recipeList (aquí podrías añadir los recipes si los necesitas)
 				new String[]{"dev.snowdrop.mtool:openrewrite-recipes:1.0.0-SNAPSHOT",
-						"org.openrewrite:rewrite-maven:8.62.4"})};
+						"org.openrewrite:rewrite-maven:8.73.0"})};
 
 		Rule.Instruction instructions = new Rule.Instruction(aiInstructions, manualInstructions,
 				openrewriteInstructions);
@@ -274,7 +274,7 @@ class RulesTest extends BaseRulesTest {
 				"Replace the SpringBoot parent dependency with Quarkus BOM within the pom.xml file.", null, // preconditions
 				null, // recipeList (aquí podrías añadir los recipes si los necesitas)
 				new String[]{"dev.snowdrop.mtool:openrewrite-recipes:1.0.0-SNAPSHOT",
-						"org.openrewrite:rewrite-maven:8.62.4"})};
+						"org.openrewrite:rewrite-maven:8.73.0"})};
 
 		Rule.Instruction instructions = new Rule.Instruction(aiInstructions, manualInstructions,
 				openrewriteInstructions);

--- a/tests/src/test/resources/cookbook/quarkus/001-springboot-replace-bom-quarkus.yaml
+++ b/tests/src/test/resources/cookbook/quarkus/001-springboot-replace-bom-quarkus.yaml
@@ -46,7 +46,7 @@
           - dev.snowdrop.mtool.openrewrite.recipe.AddQuarkusMavenPlugin
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
-          - org.openrewrite:rewrite-maven:8.71.02.4
+          - org.openrewrite:rewrite-maven:8.73.0
 
 
 


### PR DESCRIPTION
- Bump the following modules to the version: 8.73.0.
  - org.openrewrite:rewrite-maven
  - org.openrewrite:rewrite-java
- Bump the version of the maven plugin to 6.29.0
- Upgrade the openrewrite recipe BOM to 3.24.0