### PR TITLE
Bump the version of Quarkus from 3.26 to 3.31 to use TestContainer 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,12 +405,12 @@ Check the console to see the tasks executed and AI's reponses:
 ```shell
 2025-10-08 13:28:56,037 INFO  [dev.sno.com.TransformCommand] (main) 🔄 Processing migration task: springboot-replace-bom-quarkus-0000
 2025-10-08 13:28:56,039 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) Task: Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core
-2025-10-08 13:28:56,039 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) Task: The version of quarkus to be used and to included within the pom.xml properties is 3.26.4.
+2025-10-08 13:28:56,039 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) Task: The version of quarkus to be used and to included within the pom.xml properties is 3.31.3.
 2025-10-08 13:28:56,039 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) Hello! I'm your AI migration assistant.
 2025-10-08 13:28:58,981 INFO  [dev.sno.tra.pro.ai.FileSystemTool] (main) Reading file: pom.xml
 2025-10-08 13:29:15,541 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) ============= Claude response: Successfully added the Quarkus BOM dependency to the dependencyManagement section and included the quarkus-arc and quarkus-core dependencies. The Quarkus version property has also been added for version management.
 2025-10-08 13:29:18,549 INFO  [dev.sno.tra.pro.ai.FileSystemTool] (main) Reading file: pom.xml
-2025-10-08 13:29:33,810 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) ============= Claude response: Successfully updated the Quarkus version to 3.26.4 in the properties section of the pom.xml file.
+2025-10-08 13:29:33,810 INFO  [dev.sno.tra.pro.imp.AiProvider] (main) ============= Claude response: Successfully updated the Quarkus version to 3.31.3 in the properties section of the pom.xml file.
 2025-10-08 13:29:33,811 INFO  [dev.sno.tra.TransformationService] (main) ✅ Task completed successfully:    ✅ ai execution completed successfully
 ...
 ```

--- a/SCENARIO.md
+++ b/SCENARIO.md
@@ -65,7 +65,7 @@ Pom.xml updated
                         <dependency>
                                 <groupId>io.quarkus.platform</groupId>
                                 <artifactId>quarkus-bom</artifactId>
-                                <version>3.26.4</version>
+                                <version>3.31.3</version>
                                 <type>pom</type>
                                 <scope>import</scope>
                         </dependency>
@@ -142,18 +142,18 @@ public class TodoApplication implements QuarkusApplication {
           - org.openrewrite.maven.AddManagedDependency:
               groupId: io.quarkus.platform
               artifactId: quarkus-bom
-              version: 3.26.4
+              version: 3.31.3
               type: pom
               scope: import
               addToRootPom: false
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-core
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-arc
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.RemovePlugin:
               groupId: org.springframework.boot
               artifactId: spring-boot-maven-plugin

--- a/cookbook/rules/quarkus-spring-precondition/010-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus-spring-precondition/010-springboot-replace-bom-quarkus.yaml
@@ -19,18 +19,18 @@
           - org.openrewrite.maven.AddManagedDependency:
               groupId: io.quarkus.platform
               artifactId: quarkus-bom
-              version: 3.26.4
+              version: 3.31.3
               type: pom
               scope: import
               addToRootPom: false
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-core
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-arc
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.RemovePlugin:
               groupId: org.springframework.boot
               artifactId: spring-boot-maven-plugin

--- a/cookbook/rules/quarkus-spring/010-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus-spring/010-springboot-replace-bom-quarkus.yaml
@@ -15,7 +15,7 @@
     ai:
       - tasks:
           - "Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core"
-          - "The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+          - "The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
     manual:
       - todo: "Add the Quarkus BOM and quarkus-arc, quarkus-core dependencies within the pom.xml file"
     openrewrite:
@@ -25,18 +25,18 @@
           - org.openrewrite.maven.AddManagedDependency:
               groupId: io.quarkus.platform
               artifactId: quarkus-bom
-              version: 3.26.4
+              version: 3.31.3
               type: pom
               scope: import
               addToRootPom: false
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-core
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-arc
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.RemovePlugin:
               groupId: org.springframework.boot
               artifactId: spring-boot-maven-plugin

--- a/cookbook/rules/quarkus-spring/011-springboot-replace-dependency-jpa.yaml
+++ b/cookbook/rules/quarkus-spring/011-springboot-replace-dependency-jpa.yaml
@@ -16,7 +16,7 @@
     ai:
       - tasks:
           - "Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core"
-          - "The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+          - "The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
     manual:
       - todo: "Add the Quarkus BOM and quarkus-arc, quarkus-core dependencies within the pom.xml file"
     openrewrite:
@@ -26,11 +26,11 @@
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-spring-data-jpa
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-jdbc-mysql
-              version: 3.26.4
+              version: 3.31.3
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
           - org.openrewrite:rewrite-maven:8.73.0

--- a/cookbook/rules/quarkus-spring/012-springboot-replace-dependency-rest-web.yaml
+++ b/cookbook/rules/quarkus-spring/012-springboot-replace-dependency-rest-web.yaml
@@ -14,10 +14,10 @@
   order: 3
   instructions:
     ai:
-      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
       - tasks:
           - "Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core"
-          - "The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+          - "The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
     manual:
       - todo: "Add the Quarkus BOM and quarkus-arc, quarkus-core dependencies within the pom.xml file"
     openrewrite:
@@ -27,23 +27,23 @@
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-spring-web
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-spring-data-rest
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-rest
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-rest-jackson
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-smallrye-health
-              version: 3.26.4
+              version: 3.31.3
         gav:
           - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
           - org.openrewrite:rewrite-maven:8.73.0

--- a/cookbook/rules/quarkus/001-springboot-replace-bom-quarkus.yaml
+++ b/cookbook/rules/quarkus/001-springboot-replace-bom-quarkus.yaml
@@ -15,10 +15,10 @@
   order: 1
   instructions:
     ai:
-      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
       - tasks:
           - "Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core"
-          - "The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+          - "The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
     manual:
       - todo: "Add the Quarkus BOM and quarkus-arc, quarkus-core dependencies within the pom.xml file"
     openrewrite:
@@ -28,18 +28,18 @@
           - org.openrewrite.maven.AddManagedDependency:
               groupId: io.quarkus.platform
               artifactId: quarkus-bom
-              version: 3.26.4
+              version: 3.31.3
               type: pom
               scope: import
               addToRootPom: false
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-core
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-arc
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.RemovePlugin:
               groupId: org.springframework.boot
               artifactId: spring-boot-maven-plugin

--- a/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/RulesTest.java
+++ b/tests/src/test/java/dev/snowdrop/mtool/tests/analyze/RulesTest.java
@@ -144,7 +144,7 @@ class RulesTest extends BaseRulesTest {
 				// promptMessage (deprecated en favor de tasks)
 				Arrays.asList(
 						"Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core",
-						"The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."))};
+						"The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."))};
 
 		// Manual Instructions
 		Rule.Manual[] manualInstructions = new Rule.Manual[]{new Rule.Manual(

--- a/tests/src/test/resources/cookbook/quarkus/001-springboot-replace-bom-quarkus.yaml
+++ b/tests/src/test/resources/cookbook/quarkus/001-springboot-replace-bom-quarkus.yaml
@@ -15,10 +15,10 @@
   order: 1
   instructions:
     ai:
-      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+      #- promptMessage: "Can you add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core. The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
       - tasks:
           - "Add to the pom.xml file the Quarkus BOM dependency within the dependencyManagement section and the following dependencies: quarkus-arc, quarkus-core"
-          - "The version of quarkus to be used and to included within the pom.xml properties is 3.26.4."
+          - "The version of quarkus to be used and to included within the pom.xml properties is 3.31.3."
     manual:
       - todo: "Add the Quarkus BOM and quarkus-arc, quarkus-core dependencies within the pom.xml file"
     openrewrite:
@@ -28,18 +28,18 @@
           - org.openrewrite.maven.AddManagedDependency:
               groupId: io.quarkus.platform
               artifactId: quarkus-bom
-              version: 3.26.4
+              version: 3.31.3
               type: pom
               scope: import
               addToRootPom: false
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-core
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.AddDependency:
               groupId: io.quarkus
               artifactId: quarkus-arc
-              version: 3.26.4
+              version: 3.31.3
           - org.openrewrite.maven.RemovePlugin:
               groupId: org.springframework.boot
               artifactId: spring-boot-maven-plugin


### PR DESCRIPTION
- Bump the version of Quarkus from 3.26 to 3.31 to use TestContainer 2.x
- Fix the issue reported by github CI `docker client version 1.32 is too old. Minimum supported API version is 1.44`