### PR TITLE
Fix annotations dependency problem and batch OpenRewrite rules into a single Maven execution

### DIFF
--- a/cookbook/rules/quarkus-resteasy-reactive/010-replace-resteasy-deps.yaml
+++ b/cookbook/rules/quarkus-resteasy-reactive/010-replace-resteasy-deps.yaml
@@ -9,7 +9,11 @@
   message: "Migrate from RESTEasy Classic to RESTEasy Reactive (quarkus-rest)."
   ruleID: 010-replace-resteasy-deps
   when:
-    condition: pom.dependency is (gavs='io.quarkus:quarkus-resteasy')
+    condition: pom.dependency is (gavs='io.quarkus:quarkus-resteasy') OR
+     pom.dependency is (gavs='io.quarkus:quarkus-resteasy-jackson') OR
+     pom.dependency is (gavs='io.quarkus:quarkus-resteasy-jsonb') OR
+     pom.dependency is (gavs='io.quarkus:quarkus-resteasy-jaxb') OR
+     pom.dependency is (gavs='io.quarkus:quarkus-resteasy-qute')
   order: 1
   instructions:
     ai:
@@ -21,25 +25,30 @@
       - name: Replace RESTEasy Classic dependencies with RESTEasy Reactive
         description: Swap RESTEasy Classic artifacts for their Reactive equivalents and upgrade Quarkus.
         recipeList:
-          - org.openrewrite.maven.ChangeDependencyArtifactId:
-              groupId: io.quarkus
-              artifactId: quarkus-resteasy
+          - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+              oldGroupId: io.quarkus
+              oldArtifactId: quarkus-resteasy
+              newGroupId: io.quarkus
               newArtifactId: quarkus-rest
-          - org.openrewrite.maven.ChangeDependencyArtifactId:
-              groupId: io.quarkus
-              artifactId: quarkus-resteasy-jackson
+          - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+              oldGroupId: io.quarkus
+              oldArtifactId: quarkus-resteasy-jackson
+              newGroupId: io.quarkus
               newArtifactId: quarkus-rest-jackson
-          - org.openrewrite.maven.ChangeDependencyArtifactId:
-              groupId: io.quarkus
-              artifactId: quarkus-resteasy-jsonb
+          - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+              oldGroupId: io.quarkus
+              oldArtifactId: quarkus-resteasy-jsonb
+              newGroupId: io.quarkus
               newArtifactId: quarkus-rest-jsonb
-          - org.openrewrite.maven.ChangeDependencyArtifactId:
-              groupId: io.quarkus
-              artifactId: quarkus-resteasy-jaxb
+          - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+              oldGroupId: io.quarkus
+              oldArtifactId: quarkus-resteasy-jaxb
+              newGroupId: io.quarkus
               newArtifactId: quarkus-rest-jaxb
-          - org.openrewrite.maven.ChangeDependencyArtifactId:
-              groupId: io.quarkus
-              artifactId: quarkus-resteasy-qute
+          - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+              oldGroupId: io.quarkus
+              oldArtifactId: quarkus-resteasy-qute
+              newGroupId: io.quarkus
               newArtifactId: quarkus-rest-qute
           - org.openrewrite.maven.ChangePropertyValue:
               key: quarkus.platform.version

--- a/cookbook/rules/quarkus-resteasy-reactive/020-update-jaxrs-path-param-annotation.yaml
+++ b/cookbook/rules/quarkus-resteasy-reactive/020-update-jaxrs-path-param-annotation.yaml
@@ -9,8 +9,17 @@
   message: "Replace Resteasy classic PathParam annotations."
   ruleID: 020-update-jaxrs-response
   when:
-    condition: java.annotation is 'org.jboss.resteasy.annotations.jaxrs.PathParam'
-#    condition: java.annotation is 'jakarta.ws.rs.GET'
+    condition:  |
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.PathParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.QueryParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.FormParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.HeaderParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.CookieParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.jaxrs.MatrixParam' OR
+      java.annotation is 'org.jboss.resteasy.annotations.cache.Cache' OR
+      java.annotation is 'org.jboss.resteasy.annotations.cache.NoCache' OR
+      java.annotation is 'org.jboss.resteasy.annotations.SseElementType' OR
+      java.annotation is 'org.jboss.resteasy.annotations.Separator'
   order: 2
   instructions:
     ai:
@@ -25,8 +34,32 @@
           - org.openrewrite.java.ChangeType:
               oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.PathParam
               newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestPath
-#          - org.openrewrite.java.ChangeType:
-#              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.QueryParam
-#              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestQuery
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.QueryParam
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestQuery
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.FormParam
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestForm
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.HeaderParam
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestHeader
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.CookieParam
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestCookie
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.jaxrs.MatrixParam
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestMatrix
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.cache.Cache
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.Cache
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.cache.NoCache
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.NoCache
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.SseElementType
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.RestStreamElementType
+          - org.openrewrite.java.ChangeType:
+              oldFullyQualifiedTypeName: org.jboss.resteasy.annotations.Separator
+              newFullyQualifiedTypeName: org.jboss.resteasy.reactive.Separator
         gav:
           - org.openrewrite:rewrite-java:8.71.0

--- a/cookbook/rules/quarkus-resteasy-reactive/030-update-properties.yaml
+++ b/cookbook/rules/quarkus-resteasy-reactive/030-update-properties.yaml
@@ -20,15 +20,16 @@
     openrewrite:
       - name: Rename RESTEasy Classic properties to RESTEasy Reactive
         description: Convert quarkus.resteasy.* configuration properties to quarkus.rest.* equivalents.
-#        recipeList:
-#          - org.openrewrite.properties.ChangePropertyKey:
-#              oldPropertyKey: quarkus.resteasy.path
-#              newPropertyKey: quarkus.rest.path
-#          - org.openrewrite.properties.ChangePropertyKey:
-#              oldPropertyKey: quarkus.resteasy.gzip.enabled
-#              newPropertyKey: quarkus.rest.gzip.enabled
-#          - org.openrewrite.properties.ChangePropertyKey:
-#              oldPropertyKey: quarkus.resteasy.gzip.max-input
-#              newPropertyKey: quarkus.rest.gzip.max-input
         gav:
-          - org.openrewrite:rewrite-java:8.71.0
+          - dev.snowdrop.mtool:openrewrite-recipes:1.0.5-SNAPSHOT
+          - org.openrewrite:rewrite-java:8.73.0
+        recipeList:
+          - org.openrewrite.properties.ChangePropertyKey:
+              oldPropertyKey: quarkus.resteasy.path
+              newPropertyKey: 'quarkus.rest.path'
+          - org.openrewrite.properties.ChangePropertyKey:
+              oldPropertyKey: quarkus.resteasy.gzip.enabled
+              newPropertyKey: 'quarkus.rest.gzip.enabled'
+          - org.openrewrite.properties.ChangePropertyKey:
+              oldPropertyKey: quarkus.resteasy.gzip.max-input
+              newPropertyKey: 'quarkus.rest.gzip.max-input'

--- a/migration-cli/src/main/resources/application.properties
+++ b/migration-cli/src/main/resources/application.properties
@@ -68,4 +68,6 @@ quarkus.native.additional-build-args=--initialize-at-run-time=com.fasterxml.jack
 # To fix the error: the class loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @70e9c95d of the current class,
 # org/eclipse/aether/supplier/RepositorySystemSupplier, and the class loader 'app' for the method's defining class, org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory,
 # have different Class objects
-%dev.quarkus.class-loading.parent-first-artifacts=org.apache.maven.resolver:maven-resolver-supplier,org.apache.maven.resolver:maven-resolver-transport-file
+#%dev.quarkus.class-loading.parent-first-artifacts=org.apache.maven.resolver:maven-resolver-supplier,org.apache.maven.resolver:maven-resolver-transport-file
+%dev.quarkus.class-loading.parent-first-artifacts=org.apache.maven.resolver:maven-resolver-spi,org.apache.maven.resolver:maven-resolver-impl,org.apache.maven.resolver:maven-resolver-named-locks
+

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/maven/MavenQueryScanner.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/maven/MavenQueryScanner.java
@@ -111,13 +111,19 @@ public class MavenQueryScanner implements QueryScanner {
 	}
 
 	private MavenGav parse(Query query) {
-		// "gavs=group:artifact:version"
-		if (query.keyValues().containsKey("gavs")) {
-			String[] parts = query.keyValues().get("gavs").split(":");
-			return new MavenGav(parts[0], parts[1], parts.length > 2 ? parts[2] : "");
+		String gavs = query.keyValues().get("gavs");
+		String[] parts = gavs.split(":");
+
+		if (parts.length < 2) {
+			throw new IllegalArgumentException(
+					"Invalid forma for 'gavs'. 'groupId:artifactId[:version]' expected. Received: " + gavs);
 		}
-		return new MavenGav(query.keyValues().get("groupId"), query.keyValues().get("artifactId"),
-				query.keyValues().getOrDefault("version", ""));
+
+		String groupId = parts[0];
+		String artifactId = parts[1];
+		String version = parts.length > 2 ? parts[2] : "";
+
+		return new MavenGav(groupId, artifactId, version);
 	}
 
 	public Optional<InputLocation> findDependencyLocation(String pomPath, String groupId, String artifactId,

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
@@ -423,6 +423,7 @@ public class OpenRewriteQueryScanner implements QueryScanner {
 	public boolean supports(Query query) {
 		String symbol = query.symbol();
 		String fileType = query.fileType();
+		// Check the configuration to see if this query should use the Maven scanner
 		return (fileType.contains("java") && symbol.contains("annotation"))
 				|| (fileType.contains("properties") && symbol.contains("key"))
 				|| (fileType.contains("source") && symbol.contains("file"));


### PR DESCRIPTION
Fix annotations dependecy problem with latest rewrite-client.
Instead of generating one YAML file per rule (rewrite-1.yml, rewrite-2.yml, etc.) and spawning a separate mvn process for each, merge all OpenRewrite instructions into a single rewrite.yml with concatenated recipes and deduplicated GAVs. This reduces build time proportionally to the number of OpenRewrite rules.
