### PR TITLE
Bump the rewrite client to the version 0.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <ascii-table.version>1.9.0</ascii-table.version>
         <jackson.version>2.18.0</jackson.version>
         <opencsv.version>5.12.0</opencsv.version>
-        <rewrite-client.version>0.2.4</rewrite-client.version>
+        <rewrite-client.version>0.2.6</rewrite-client.version>
 
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven-formatter-plugin.version>2.29.0</maven-formatter-plugin.version>


### PR DESCRIPTION
- Bump the rewrite client to the version 0.2.6 
- This version of the client fixes the issue discovered (resteasy-core-spi missing and containing the REST annotations) as some transitive dependencies issue were not loaded