### PR TITLE
Add the support of the Quarkus Langchain4j Vertex AI Anthropic client

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -21,4 +21,4 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Build and test
-        run: mvn clean install -ntp
+        run: mvn clean install -ntp -B

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/ContentMapper.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/ContentMapper.java
@@ -7,6 +7,7 @@ import java.util.*;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicTool;
@@ -20,6 +21,8 @@ public class ContentMapper {
 
     /**
      * Generate the Request from the list of the chat messages and VertexAiconfig
+     * The request structure has been designed according to the Claude API spec:
+     * <a href="https://platform.claude.com/docs/en/api/java/messages/create">Claude API</a>
      *
      * @param messages the Chat Messages
      * @param vertexAiConfig
@@ -47,11 +50,11 @@ public class ContentMapper {
         }
 
         List<GenerateRequest.Message> requestMessages = new ArrayList<>();
+        String systemMessage = "";
 
         for (ChatMessage message : messages) {
             switch (message.type()) {
-                case SYSTEM -> requestMessages
-                        .add(new GenerateRequest.Message(Role.SYSTEM.name().toLowerCase(), chatMessageToText(message)));
+                case SYSTEM -> systemMessage = chatMessageToText(message);
                 case USER -> requestMessages
                         .add(new GenerateRequest.Message(Role.USER.name().toLowerCase(), chatMessageToText(message)));
                 case AI -> requestMessages
@@ -71,6 +74,7 @@ public class ContentMapper {
                 ANTHROPIC_VERSION,
                 vertexAiConfig.maxOutputTokens,
                 requestMessages,
+                systemMessage,
                 toTools(toolSpecifications, vertexAiConfig.strict),
                 anthropicThinking);
     }

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/GenerateRequest.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/GenerateRequest.java
@@ -11,6 +11,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicTool;
 public record GenerateRequest(String anthropic_version,
         Integer max_tokens,
         List<Message> messages,
+        String system,
         List<AnthropicTool> tools,
         AnthropicThinking thinking) {
     public record Message(

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicChatModel.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicChatModel.java
@@ -32,6 +32,7 @@ public class VertexAiAnthropicChatModel extends VertexAiBaseChatModel {
                 builder.toolChoice,
                 builder.logRequests,
                 builder.logResponses,
+                builder.logCurl,
                 builder.strict,
                 builder.timeout,
                 builder.includeThoughts,
@@ -52,10 +53,12 @@ public class VertexAiAnthropicChatModel extends VertexAiBaseChatModel {
                     .connectTimeout(builder.timeout.toSeconds(), TimeUnit.SECONDS)
                     .readTimeout(builder.timeout.toSeconds(), TimeUnit.SECONDS);
 
-            if (builder.logRequests || builder.logResponses) {
+            if (builder.logRequests || builder.logResponses || builder.logCurl) {
                 restApiBuilder.loggingScope(LoggingScope.REQUEST_RESPONSE);
-                restApiBuilder.clientLogger(new VertexAiRestApi.VertxAiClientLogger(builder.logRequests,
-                        builder.logResponses));
+                restApiBuilder.clientLogger(new VertexAiRestApi.VertxAiClientLogger(
+                        builder.logRequests,
+                        builder.logResponses,
+                        builder.logCurl));
             }
             restApiBuilder.register(new ModelAuthProviderFilter(builder.modelId));
             restApi = restApiBuilder.build(VertexAiRestApi.class);
@@ -93,6 +96,7 @@ public class VertexAiAnthropicChatModel extends VertexAiBaseChatModel {
         private Duration timeout = Duration.ofSeconds(10);
         private Boolean logRequests = false;
         private Boolean logResponses = false;
+        private Boolean logCurl;
         private List<ChatModelListener> listeners = Collections.emptyList();
         private Boolean strict = false;
 
@@ -172,6 +176,11 @@ public class VertexAiAnthropicChatModel extends VertexAiBaseChatModel {
 
         public Builder logResponses(boolean logResponses) {
             this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder logCurl(boolean logCurl) {
+            this.logCurl = logCurl;
             return this;
         }
 

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicChatModel.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicChatModel.java
@@ -96,7 +96,7 @@ public class VertexAiAnthropicChatModel extends VertexAiBaseChatModel {
         private Duration timeout = Duration.ofSeconds(10);
         private Boolean logRequests = false;
         private Boolean logResponses = false;
-        private Boolean logCurl;
+        private Boolean logCurl = false;
         private List<ChatModelListener> listeners = Collections.emptyList();
         private Boolean strict = false;
 

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicRecorder.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiAnthropicRecorder.java
@@ -66,7 +66,8 @@ public class VertexAiAnthropicRecorder {
                     .publisher(aiConfig.publisher())
                     .modelId(modelId)
                     .logRequests(firstOrDefault(false, aiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, aiConfig.logResponses()));
+                    .logResponses(firstOrDefault(false, aiConfig.logResponses()))
+                    .logCurl(firstOrDefault(false, aiConfig.logRequestsCurl()));
 
             if (aiConfig.timeout().isPresent()) {
                 builder.timeout(aiConfig.timeout().get());

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiBaseChatModel.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiBaseChatModel.java
@@ -30,6 +30,7 @@ public abstract class VertexAiBaseChatModel implements ChatModel {
     protected final ToolChoice toolChoice;
     protected final Boolean logRequests;
     protected final Boolean logResponses;
+    protected final Boolean logCurl;
     protected final Duration timeout;
 
     // See: https://platform.claude.com/docs/en/api/messages#tool.strict
@@ -49,6 +50,7 @@ public abstract class VertexAiBaseChatModel implements ChatModel {
             ToolChoice toolChoice,
             Boolean logRequests,
             Boolean logResponses,
+            Boolean logCurl,
             Boolean strict,
             Duration timeout,
             boolean includeThoughts,
@@ -63,6 +65,7 @@ public abstract class VertexAiBaseChatModel implements ChatModel {
         this.toolChoice = toolChoice;
         this.logRequests = logRequests;
         this.logResponses = logResponses;
+        this.logCurl = logCurl;
         this.strict = strict;
         this.timeout = timeout;
         this.includeThoughts = includeThoughts;

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiRestApi.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/VertexAiRestApi.java
@@ -6,6 +6,7 @@ import static java.util.stream.StreamSupport.stream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.quarkiverse.langchain4j.runtime.CurlRequestLogger;
 import jakarta.ws.rs.*;
 
 import org.jboss.logging.Logger;
@@ -97,10 +98,12 @@ public interface VertexAiRestApi {
 
         private final boolean logRequests;
         private final boolean logResponses;
+        private final boolean logCurl;
 
-        public VertxAiClientLogger(boolean logRequests, boolean logResponses) {
+        public VertxAiClientLogger(boolean logRequests, boolean logResponses, boolean logCurl) {
             this.logRequests = logRequests;
             this.logResponses = logResponses;
+            this.logCurl = logCurl;
         }
 
         @Override
@@ -121,6 +124,9 @@ public interface VertexAiRestApi {
                         bodyToString(body));
             } catch (Exception e) {
                 log.warn("Failed to log request", e);
+            }
+            if (logCurl) {
+                CurlRequestLogger.logCurl(log, request, body);
             }
         }
 

--- a/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/config/VertexAiAnthropicConfig.java
+++ b/ai-providers/vertex-ai-anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/anthropic/config/VertexAiAnthropicConfig.java
@@ -93,6 +93,13 @@ public interface VertexAiAnthropicConfig {
         Optional<Boolean> logResponses();
 
         /**
+         * Whether the Anthropic client should log requests as cURL commands
+         */
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests-curl}")
+        Optional<Boolean> logRequestsCurl();
+
+        /**
          * Global timeout for requests to Vertex AI APIs
          */
         @ConfigDocDefault("10s")

--- a/ai-providers/vertex-ai-examples/pom.xml
+++ b/ai-providers/vertex-ai-examples/pom.xml
@@ -43,4 +43,24 @@
             <version>2.0.17</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <!-- Disable inherited quarkus-maven-plugin executions for the deployment module
+                         to avoid circular dependency resolution during generate-code phase -->
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                        </goals>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ai-providers/vertex-ai-examples/src/main/resources/application.properties
+++ b/ai-providers/vertex-ai-examples/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.langchain4j.log-requests=true
 quarkus.langchain4j.log-responses=true
+quarkus.langchain4j.log-requests-curl=true
 quarkus.langchain4j.timeout=30
 
 quarkus.langchain4j.vertexai.anthropic.location=europe-west1

--- a/migration-cli/pom.xml
+++ b/migration-cli/pom.xml
@@ -64,10 +64,18 @@
         </dependency>
 
         <!-- AI -->
+        <!-- This client only works if we have an API_KEY to access the Anthropic Claude API !
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-anthropic</artifactId>
             <version>1.7.4</version>
+        </dependency>
+        -->
+        <!-- Using the Vertex AI Anthropic API able to access Anthropic on Google Cloud platform -->
+        <dependency>
+            <groupId>dev.snowdrop.mtool.ai</groupId>
+            <artifactId>vertex-ai-anthropic</artifactId>
+            <version>1.0.5-SNAPSHOT</version>
         </dependency>
 
         <!-- lsp4j -->
@@ -85,7 +93,30 @@
                 <version>${os-maven-plugin.version}</version>
             </extension>
         </extensions>
+
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <configuration>
+                    <skip>${quarkus.build.skip}</skip>
+                </configuration>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
+
 
     <profiles>
         <profile>

--- a/migration-cli/src/main/resources/application.properties
+++ b/migration-cli/src/main/resources/application.properties
@@ -34,17 +34,25 @@ quarkus.log.category."io.quarkus".min-level=ERROR
 quarkus.log.category."io.quarkiverse.langchain4j".level=INFO
 quarkus.log.category."dev.snowdrop.mtool.transform".level=INFO
 
-# AI - Langchain and anthropic Model
+# Quarkus - Langchain4j
 quarkus.langchain4j.log-requests=false
 quarkus.langchain4j.log-responses=false
-quarkus.langchain4j.anthropic.log-requests-curl=false
-quarkus.langchain4j.anthropic.disable-beta-header=true
+quarkus.langchain4j.timeout=30S
 
-quarkus.langchain4j.anthropic.api-key.base-url=""
-quarkus.langchain4j.anthropic.api-key=""
-quarkus.langchain4j.anthropic.timeout=30s
-quarkus.langchain4j.anthropic.chat-model.model-name=""
-quarkus.langchain4j.anthropic.chat-model.max-tokens=4096
+# Quarkus Langchain4j - Vertex AI Anthropic Client
+quarkus.langchain4j.vertexai.anthropic.location=europe-west1
+quarkus.langchain4j.vertexai.anthropic.project-id=itpc-gcp-cp-pe-eng-claude
+quarkus.langchain4j.vertexai.anthropic.model-id=claude-opus-4-6
+quarkus.langchain4j.vertexai.anthropic.chat-model.max-output-tokens=10000
+
+# Quarkus Langchain4j - Anthropic client - Only works if you have an API_KEY !
+# quarkus.langchain4j.anthropic.log-requests-curl=false
+# quarkus.langchain4j.anthropic.disable-beta-header=true
+# quarkus.langchain4j.anthropic.api-key.base-url=""
+# quarkus.langchain4j.anthropic.api-key=""
+# quarkus.langchain4j.anthropic.timeout=30s
+# quarkus.langchain4j.anthropic.chat-model.model-name=""
+# quarkus.langchain4j.anthropic.chat-model.max-tokens=4096
 
 # Graalvm issue
 # Error: Class initialization of com.fasterxml.jackson.module.jaxb.deser.DataHandlerJsonDeserializer failed. This error is reported at image build time because class com.fasterxml.jackson.module.jaxb.deser.DataHandlerJsonDeserializer is registered for linking at image build time by command line and command line. Use the option

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
     </properties>
 
     <modules>
+        <module>ai-providers</module>
         <module>openrewrite-recipes</module>
         <module>model</module>
         <module>parser</module>
         <module>scanner</module>
         <module>migration-cli</module>
         <module>tests</module>
-        <module>ai-providers</module>
     </modules>
 
     <developers>
@@ -282,25 +282,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <configuration>
-                    <skip>${quarkus.build.skip}</skip>
-                </configuration>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                            <goal>native-image-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>


### PR DESCRIPTION
- Add the Quarkus Langchain4j Vertex AI Anthropic client part of this project till Google GenAI SDK will support partner models and upstream project: langchain'j and quarkus-langchain4j will support it
- Improve the code to better define the parameters of the LLM and Vertex AI Anthropic
- Fix the issue to support to pass a System message to the LLM
- Enable to log the curl request using the property `quarkus.langchain4j.log-requests-curl=true`
- Configure `mtool` to use it with the command `mtool . transform -p ai`. This has been fully tested :-) 