### PR TITLE
Dependabot/maven/org.openrewrite.recipe rewrite recipe bom 3.27.1

### DIFF
--- a/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/recipe/java/CreateJavaClassFromTemplate.java
+++ b/openrewrite-recipes/src/main/java/dev/snowdrop/mtool/openrewrite/recipe/java/CreateJavaClassFromTemplate.java
@@ -61,6 +61,10 @@ public class CreateJavaClassFromTemplate extends ScanningRecipe<AtomicBoolean> {
     @Nullable
     String relativePath;
 
+    @Option(displayName = "Maven artifact name to add to the classpath", description = "Maven artifact name to add to the classpath", required = false, example = "quarkus-core")
+    @Nullable
+    String artifactName;
+
     @Override
     public String getDisplayName() {
         return "Create Java class";
@@ -110,7 +114,9 @@ public class CreateJavaClassFromTemplate extends ScanningRecipe<AtomicBoolean> {
 
     private Stream<SourceFile> createEmptyClass() {
         String packageModifier = "package-private".equals(modifier) ? "" : modifier + " ";
-        return JavaParser.fromJavaVersion().build()
+        return JavaParser.fromJavaVersion()
+                .classpath(artifactName)
+                .build()
                 .parse(String.format(classTemplate, packageName, packageModifier, className))
                 .map(brandNewFile -> brandNewFile.withSourcePath(getSourcePath()));
     }

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/java/CreateJavaClassTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/java/CreateJavaClassTest.java
@@ -10,7 +10,7 @@ public class CreateJavaClassTest implements RewriteTest {
 
     private final String classTemplate = """
             package %s;
-
+            import io.quarkus.runtime.QuarkusApplication;
             %sclass %s implements QuarkusApplication {
                 @Override
                 public int run(String... args) throws Exception {
@@ -22,12 +22,13 @@ public class CreateJavaClassTest implements RewriteTest {
 
     @Test
     void shouldCreateTodoApplicationClass() {
+        CreateJavaClassFromTemplate javaTodoClass = new CreateJavaClassFromTemplate(classTemplate, "src/main/java",
+                "org.openrewrite.example", "public", "TodoApplication", null, "foo/bar", "quarkus-core");
         rewriteRun(
-                spec -> spec.recipe(new CreateJavaClassFromTemplate(classTemplate, "src/main/java",
-                        "org.openrewrite.example", "public", "TodoApplication", null, "foo/bar")),
+                spec -> spec.recipe(javaTodoClass),
                 java(doesNotExist(), """
                         package org.openrewrite.example;
-
+                        import io.quarkus.runtime.QuarkusApplication;
                         public class TodoApplication implements QuarkusApplication {
                             @Override
                             public int run(String... args) throws Exception {

--- a/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/quarkus/MigrateSpringBootToQuarkusTest.java
+++ b/openrewrite-recipes/src/test/java/dev/snowdrop/mtool/openrewrite/quarkus/MigrateSpringBootToQuarkusTest.java
@@ -67,7 +67,7 @@ public class MigrateSpringBootToQuarkusTest implements RewriteTest {
                 .recipes(new ReplaceSpringBootApplicationWithQuarkusMainAnnotation(),
                         new RemoveMethodInvocations("org.springframework.boot.SpringApplication run(..)"),
                         new CreateJavaClassFromTemplate(todoClassTemplate, "src/main/java", "com.todo.app", "public",
-                                "TodoApplication", false, ""),
+                                "TodoApplication", false, "", ""),
                         new AddQuarkusRun(""))
 
                 .parser((Parser.Builder) JavaParser.fromJavaVersion().dependsOn("""

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <langchain4j-vertex-ai-anthropic.version>1.12.2-beta22</langchain4j-vertex-ai-anthropic.version>
         <lombok.version>1.18.42</lombok.version>
         <org.eclipse.lsp4j.version>0.24.0</org.eclipse.lsp4j.version>
-        <openrewrite-recipe-bom.version>3.24.0</openrewrite-recipe-bom.version>
+        <openrewrite-recipe-bom.version>3.27.1</openrewrite-recipe-bom.version>
         <opencsv.version>5.12.0</opencsv.version>
         <quarkus-langchain4j-testing-internal.version>0.20.3</quarkus-langchain4j-testing-internal.version>
         <quarkus-langchain4j.version>1.8.4</quarkus-langchain4j.version>

--- a/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
+++ b/scanner/src/main/java/dev/snowdrop/mtool/scanner/openrewrite/OpenRewriteQueryScanner.java
@@ -283,10 +283,10 @@ public class OpenRewriteQueryScanner implements QueryScanner {
         }
 
         // Recipe's jar files declared within the openrewrite pom
-        // Bom of the recipe: https://repo.maven.apache.org/maven2/org/openrewrite/recipe/rewrite-recipe-bom/3.24.0/rewrite-recipe-bom-3.24.0.pom
-        // Bom of the modules of rewrite: https://repo.maven.apache.org/maven2/org/openrewrite/rewrite-bom/8.73.0/rewrite-bom-8.73.0.pom
-        String gavs = "org.openrewrite:rewrite-java:8.73.0,"
-                + "org.openrewrite.recipe:rewrite-java-dependencies:1.51.0,"
+        // Bom of the recipe: https://repo.maven.apache.org/maven2/org/openrewrite/recipe/rewrite-recipe-bom/3.27.1/rewrite-recipe-bom-3.27.1.pom
+        // Bom of the modules of rewrite: https://repo.maven.apache.org/maven2/org/openrewrite/rewrite-bom/8.78.5/rewrite-bom-8.78.5.pom
+        String gavs = "org.openrewrite:rewrite-java:8.78.5,"
+                + "org.openrewrite.recipe:rewrite-java-dependencies:1.53.0,"
                 + "dev.snowdrop.mtool:openrewrite-recipes:1.0.4";
         Map<String, Map<String, String>> recipeMap = (Map<String, Map<String, String>>) first;
 


### PR DESCRIPTION
- Add a new parameter `artifactName` to the recipe: `CreateJavaClassFromTemplate` to allow to specify an additional artifact to be added to the java parser classpath."
- Bump the version of the bom of openrewrite to 3.27.1